### PR TITLE
Improve steps page error handling

### DIFF
--- a/src/app/api/steps/route.js
+++ b/src/app/api/steps/route.js
@@ -4,8 +4,8 @@ import { getTccInfoByUserIdInMembersAction } from '@/server/controllers/tcc/read
 export async function GET() {
     try {
         const tcc = await getTccInfoByUserIdInMembersAction()
-        return tcc
+        return NextResponse.json(tcc)
     } catch (error) {
-        return NextResponse.json({ data: [] }, { status: 500 })
+        return NextResponse.json({ data: [], success: false, message: 'Erro ao buscar etapas.' }, { status: 500 })
     }
 }

--- a/src/app/interface/student/steps/page.js
+++ b/src/app/interface/student/steps/page.js
@@ -3,24 +3,48 @@ import ButtonSubmit from '@/app/components/ButtonSubmit'
 import { useEffect, useState } from 'react'
 
 export default function Page() {
-    const [steps, setSteps] = useState()
+    const [steps, setSteps] = useState([])
+    const [isLoading, setIsLoading] = useState(true)
+    const [hasError, setHasError] = useState(false)
 
     useEffect(() => {
-        async function AllSteps() {
-            const res = await fetch('/api/steps')
-            const json = await res.json()
-            setSteps(json.data)
+        async function allSteps() {
+            try {
+                const res = await fetch('/api/steps')
+                if (!res.ok) {
+                    throw new Error('Failed to fetch steps')
+                }
+
+                const data = await res.json().catch(() => ({ data: [] }))
+                setSteps(data.data || [])
+            } catch (_error) {
+                setHasError(true)
+                setSteps([])
+            } finally {
+                setIsLoading(false)
+            }
         }
 
-        AllSteps()
+        allSteps()
     }, [])
 
-    if (!steps) {
+    if (isLoading) {
         return (
             <section className="dashboard">
                 <div className="px-4 py-5">
                     <h1 className="text-black fs-4">Etapas</h1>
-                    <p className="text-muted">Nenhuma etapa encontrada.</p>
+                    <p className="text-muted">Carregando...</p>
+                </div>
+            </section>
+        )
+    }
+
+    if (hasError || steps.length === 0) {
+        return (
+            <section className="dashboard">
+                <div className="px-4 py-5">
+                    <h1 className="text-black fs-4">Etapas</h1>
+                    <p className="text-muted">{hasError ? 'Erro ao carregar etapas.' : 'Nenhuma etapa encontrada.'}</p>
                 </div>
             </section>
         )


### PR DESCRIPTION
## Summary
- handle unexpected responses for steps API
- show loading and error states on student steps page
- ensure `/api/steps` always returns JSON

## Testing
- `npx eslint src/app/api/steps/route.js src/app/interface/student/steps/page.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6395668fc832e9265bff7e77cbc06